### PR TITLE
README:md: use main version in docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ SDK for building Embedded Controller firmware
 ```bash
 git clone git@github.com:Dasharo/ec.git
 cd ec
-docker run --rm -it -v $PWD:$PWD -w $PWD ghcr.io/dasharo/ec-sdk
+docker run --rm -it -v $PWD:$PWD -w $PWD ghcr.io/dasharo/ec-sdk:main
 make BOARD=system76/darp
 ```


### PR DESCRIPTION
`latest` is not available, but `main` is.