### PR TITLE
update to debian:oldstable-20260223-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:oldstable-20220125-slim
+FROM debian:oldstable-20260223-slim
 
 USER root
 


### PR DESCRIPTION
It upgrades SDCC from 3.8.0 to 4.5.0: https://packages.debian.org/search?keywords=sdcc

Currently, it DOES NOT build our EC firmware.